### PR TITLE
chore: update `CreateBucketSynPackage` to keep aligned with greenfield

### DIFF
--- a/contracts/middle-layer/AdditionalBucketHub.sol
+++ b/contracts/middle-layer/AdditionalBucketHub.sol
@@ -26,13 +26,19 @@ contract AdditionalBucketHub is NFTWrapResourceStorage, Initializable, AccessCon
     struct CreateSynPackage {
         address creator;
         string name;
-        bool isPublic;
+        VisibilityType visibility;
         address paymentAddress;
         address primarySpAddress;
         uint256 primarySpApprovalExpiredHeight;
         bytes primarySpSignature; // TODO if the owner of the bucket is a smart contract, we are not able to get the primarySpSignature
         uint256 readQuota;
         bytes extraData; // rlp encode of ExtraData
+    }
+
+    enum VisibilityType {
+        PublicRead,
+        Private,
+        Default // If the bucket Visibility is default, it's finally set to private.
     }
 
     /*----------------- external function -----------------*/
@@ -241,7 +247,7 @@ contract AdditionalBucketHub is NFTWrapResourceStorage, Initializable, AccessCon
         bytes[] memory elements = new bytes[](9);
         elements[0] = synPkg.creator.encodeAddress();
         elements[1] = bytes(synPkg.name).encodeBytes();
-        elements[2] = synPkg.isPublic.encodeBool();
+        elements[2] = uint256(synPkg.visibility).encodeUint();
         elements[3] = synPkg.paymentAddress.encodeAddress();
         elements[4] = synPkg.primarySpAddress.encodeAddress();
         elements[5] = synPkg.primarySpApprovalExpiredHeight.encodeUint();

--- a/contracts/middle-layer/BucketHub.sol
+++ b/contracts/middle-layer/BucketHub.sol
@@ -20,13 +20,19 @@ contract BucketHub is NFTWrapResourceHub, AccessControl {
     struct CreateSynPackage {
         address creator;
         string name;
-        bool isPublic;
+        VisibilityType visibility;
         address paymentAddress;
         address primarySpAddress;
         uint256 primarySpApprovalExpiredHeight;
         bytes primarySpSignature; // TODO if the owner of the bucket is a smart contract, we are not able to get the primarySpSignature
         uint256 readQuota;
         bytes extraData; // rlp encode of ExtraData
+    }
+
+    enum VisibilityType {
+        PublicRead,
+        Private,
+        Default // If the bucket Visibility is default, it's finally set to private.
     }
 
     function initialize(address _ERC721_token, address _additional) public initializer {

--- a/foundry-tests/BucketHub.t.sol
+++ b/foundry-tests/BucketHub.t.sol
@@ -77,7 +77,7 @@ contract BucketHubTest is Test, BucketHub {
         CreateSynPackage memory synPkg = CreateSynPackage({
             creator: address(this),
             name: "test",
-            isPublic: true,
+            visibility: VisibilityType.PublicRead,
             paymentAddress: address(this),
             primarySpAddress: address(this),
             primarySpApprovalExpiredHeight: 0,
@@ -124,7 +124,7 @@ contract BucketHubTest is Test, BucketHub {
         CreateSynPackage memory synPkg = CreateSynPackage({
             creator: granter,
             name: "test1",
-            isPublic: true,
+            visibility: VisibilityType.PublicRead,
             paymentAddress: address(this),
             primarySpAddress: address(this),
             primarySpApprovalExpiredHeight: 0,
@@ -204,7 +204,7 @@ contract BucketHubTest is Test, BucketHub {
         CreateSynPackage memory synPkg = CreateSynPackage({
             creator: address(this),
             name: "test",
-            isPublic: true,
+            visibility: VisibilityType.PublicRead,
             paymentAddress: address(this),
             primarySpAddress: address(this),
             primarySpApprovalExpiredHeight: 0,
@@ -242,7 +242,7 @@ contract BucketHubTest is Test, BucketHub {
         CreateSynPackage memory synPkg = CreateSynPackage({
             creator: address(this),
             name: "test",
-            isPublic: true,
+            visibility: VisibilityType.PublicRead,
             paymentAddress: address(this),
             primarySpAddress: address(this),
             primarySpApprovalExpiredHeight: 0,
@@ -298,10 +298,11 @@ contract BucketHubTest is Test, BucketHub {
     }
 
     function _encodeCreateAckPackage(uint32 status, uint256 id, address creator) internal pure returns (bytes memory) {
-        bytes[] memory elements = new bytes[](3);
+        bytes[] memory elements = new bytes[](4);
         elements[0] = status.encodeUint();
         elements[1] = id.encodeUint();
         elements[2] = creator.encodeAddress();
+        elements[3] = "".encodeBytes();
         return _RLPEncode(TYPE_CREATE, elements.encodeList());
     }
 
@@ -328,9 +329,10 @@ contract BucketHubTest is Test, BucketHub {
     }
 
     function _encodeDeleteAckPackage(uint32 status, uint256 id) internal pure returns (bytes memory) {
-        bytes[] memory elements = new bytes[](2);
+        bytes[] memory elements = new bytes[](3);
         elements[0] = status.encodeUint();
         elements[1] = id.encodeUint();
+        elements[2] = "".encodeBytes();
         return _RLPEncode(TYPE_DELETE, elements.encodeList());
     }
 
@@ -357,7 +359,7 @@ contract BucketHubTest is Test, BucketHub {
         bytes[] memory elements = new bytes[](9);
         elements[0] = synPkg.creator.encodeAddress();
         elements[1] = bytes(synPkg.name).encodeBytes();
-        elements[2] = synPkg.isPublic.encodeBool();
+        elements[2] = uint256(synPkg.visibility).encodeUint();
         elements[3] = synPkg.paymentAddress.encodeAddress();
         elements[4] = synPkg.primarySpAddress.encodeAddress();
         elements[5] = synPkg.primarySpApprovalExpiredHeight.encodeUint();

--- a/foundry-tests/GroupHub.t.sol
+++ b/foundry-tests/GroupHub.t.sol
@@ -301,10 +301,11 @@ contract GroupHubTest is Test, GroupHub {
     }
 
     function _encodeCreateAckPackage(uint32 status, uint256 id, address creator) internal pure returns (bytes memory) {
-        bytes[] memory elements = new bytes[](3);
+        bytes[] memory elements = new bytes[](4);
         elements[0] = status.encodeUint();
         elements[1] = id.encodeUint();
         elements[2] = creator.encodeAddress();
+        elements[3] = "".encodeBytes();
         return _RLPEncode(TYPE_CREATE, elements.encodeList());
     }
 
@@ -331,9 +332,10 @@ contract GroupHubTest is Test, GroupHub {
     }
 
     function _encodeDeleteAckPackage(uint32 status, uint256 id) internal pure returns (bytes memory) {
-        bytes[] memory elements = new bytes[](2);
+        bytes[] memory elements = new bytes[](3);
         elements[0] = status.encodeUint();
         elements[1] = id.encodeUint();
+        elements[2] = "".encodeBytes();
         return _RLPEncode(TYPE_DELETE, elements.encodeList());
     }
 
@@ -362,12 +364,13 @@ contract GroupHubTest is Test, GroupHub {
             members[i] = ackPkg.members[i].encodeAddress();
         }
 
-        bytes[] memory elements = new bytes[](5);
+        bytes[] memory elements = new bytes[](6);
         elements[0] = ackPkg.status.encodeUint();
-        elements[1] = ackPkg.operator.encodeAddress();
-        elements[2] = ackPkg.id.encodeUint();
+        elements[1] = ackPkg.id.encodeUint();
+        elements[2] = ackPkg.operator.encodeAddress();
         elements[3] = ackPkg.opType.encodeUint();
         elements[4] = members.encodeList();
+        elements[5] = "".encodeBytes();
         return _RLPEncode(TYPE_UPDATE, elements.encodeList());
     }
 

--- a/foundry-tests/ObjectHub.t.sol
+++ b/foundry-tests/ObjectHub.t.sol
@@ -250,9 +250,10 @@ contract ObjectHubTest is Test, ObjectHub {
     }
 
     function _encodeDeleteAckPackage(uint32 status, uint256 id) internal pure returns (bytes memory) {
-        bytes[] memory elements = new bytes[](2);
+        bytes[] memory elements = new bytes[](3);
         elements[0] = status.encodeUint();
         elements[1] = id.encodeUint();
+        elements[2] = "".encodeBytes();
         return _RLPEncode(TYPE_DELETE, elements.encodeList());
     }
 


### PR DESCRIPTION
### Description

This pr aims to update `CreateBucketSynPackage` struct.

### Rationale

To keep aligned with greenfield

### Changes

Notable changes:
* Change `isPublic` field to `Visibility`