### PR TITLE
fix: typo in `revoke` function

### DIFF
--- a/contracts/middle-layer/AdditionalGroupHub.sol
+++ b/contracts/middle-layer/AdditionalGroupHub.sol
@@ -114,7 +114,7 @@ contract AdditionalGroupHub is NFTWrapResourceStorage, Initializable, AccessCont
             revokeRole(ROLE_DELETE, account);
         }
         if (acCode & AUTH_CODE_UPDATE != 0) {
-            acCode = acCode & ~AUTH_CODE_DELETE;
+            acCode = acCode & ~AUTH_CODE_UPDATE;
             revokeRole(ROLE_UPDATE, account);
         }
 


### PR DESCRIPTION
### Description

This pr aims to fix typo in groupHub `revoke` function.

### Changes

Notable changes:
* `AUTH_CODE_DELETE` should be `AUTH_CODE_UPDATE`