### PR TITLE
fix(lightClient): set `validatorSetChanged` to `true` while syncLightBlock

### DIFF
--- a/contracts/GnfdLightClient.sol
+++ b/contracts/GnfdLightClient.sol
@@ -104,7 +104,8 @@ contract GnfdLightClient is Initializable, Config, ILightClient {
             tmp := mload(ptr)
         }
 
-        bool validatorSetChanged = (tmp >> 248) != 0x00;
+        // TODO: we will optimize here in the next version
+        bool validatorSetChanged = true;
         uint256 consensusStateLength = tmp & 0xffffffffffffffff;
         ptr = ptr + CONSENSUS_STATE_BYTES_LENGTH;
 


### PR DESCRIPTION
### Description

set `validatorSetChanged` to `true` while syncLightBlock

### Rationale

The current precompile contract always returns `validatorSetChanged` to false, so the contract defaults to true to keep the validators changed as expected


### Changes

Notable changes:
* set `validatorSetChanged` to `true` while syncLightBlock
* ...