### PR TITLE
feat: modify bls verify quorum calculation

### DIFF
--- a/contracts/GnfdLightClient.sol
+++ b/contracts/GnfdLightClient.sol
@@ -288,7 +288,7 @@ contract GnfdLightClient is Initializable, Config, ILightClient {
         return (400_001, "GnfdLightClient", "init version");
     }
 
-    function ceilDiv(uint256 x, uint256 y) internal pure {
+    function ceilDiv(uint256 x, uint256 y) internal pure returns(uint256) {
         if (y == 0) return 0;
         return (x + y - 1) / y;
     }

--- a/contracts/GnfdLightClient.sol
+++ b/contracts/GnfdLightClient.sol
@@ -132,8 +132,9 @@ contract GnfdLightClient is Initializable, Config, ILightClient {
                 input = abi.encodePacked(input, validatorSet[i].relayerBlsKey);
             }
         }
-        require(bitCount > (validatorSet.length * 2) / 3, "no majority validators");
 
+        uint256 _quorum = ceilDiv(validatorSet.length * 2, 3);
+        require(bitCount >= _quorum, "no majority validators");
         (bool success, bytes memory result) = PACKAGE_VERIFY_CONTRACT.staticcall(input);
         return success && result.length > 0;
     }
@@ -285,6 +286,11 @@ contract GnfdLightClient is Initializable, Config, ILightClient {
         returns (uint256 version, string memory name, string memory description)
     {
         return (400_001, "GnfdLightClient", "init version");
+    }
+
+    function ceilDiv(uint256 x, uint256 y) internal pure {
+        if (y == 0) return 0;
+        return (x + y - 1) / y;
     }
 
     function updateParam(string calldata key, bytes calldata value) external onlyGov {

--- a/contracts/GnfdLightClient.sol
+++ b/contracts/GnfdLightClient.sol
@@ -134,7 +134,7 @@ contract GnfdLightClient is Initializable, Config, ILightClient {
         }
 
         uint256 _quorum = ceilDiv(validatorSet.length * 2, 3);
-        require(bitCount >= _quorum, "no majority validators");
+        require(_quorum > 0 && bitCount >= _quorum, "no majority validators");
         (bool success, bytes memory result) = PACKAGE_VERIFY_CONTRACT.staticcall(input);
         return success && result.length > 0;
     }


### PR DESCRIPTION
### Description

modify bls verify quorum calculation

### Rationale

sync with greenfield bls quorum calculation

### Example
while validators length is 13, old quorum is 8 and new quorum is 9
while validators length is 14, old quorum is 8 and new quorum is 10
while validators length is 15, old quorum is 10 and  new quorum is 10
while validators length is 16, old quorum is 10 and  new quorum is 11
