### PR TITLE
chore: rename `AccessControl` to `GnfdAccessControl`

### DIFF
--- a/contracts/interface/IBucketHub.sol
+++ b/contracts/interface/IBucketHub.sol
@@ -2,7 +2,6 @@
 
 pragma solidity ^0.8.0;
 
-import "./ICmnHub.sol";
 import "../middle-layer/resource-mirror/storage/BucketStorage.sol";
 
 interface IBucketHub {

--- a/contracts/interface/IGnfdAccessControl.sol
+++ b/contracts/interface/IGnfdAccessControl.sol
@@ -2,7 +2,7 @@
 
 pragma solidity ^0.8.0;
 
-interface IAccessControl {
+interface IGnfdAccessControl {
     function hasRole(bytes32 role, address granter, address account) external view returns (bool);
 
     function grantRole(bytes32 role, address grantee, uint256 expireTime) external;

--- a/contracts/interface/IGroupHub.sol
+++ b/contracts/interface/IGroupHub.sol
@@ -2,7 +2,6 @@
 
 pragma solidity ^0.8.0;
 
-import "./ICmnHub.sol";
 import "../middle-layer/resource-mirror/storage/GroupStorage.sol";
 
 interface IGroupHub {

--- a/contracts/interface/IObjectHub.sol
+++ b/contracts/interface/IObjectHub.sol
@@ -2,10 +2,11 @@
 
 pragma solidity ^0.8.0;
 
-import "./ICmnHub.sol";
 import "../middle-layer/resource-mirror/storage/ObjectStorage.sol";
 
 interface IObjectHub {
+    function deleteObject(uint256 tokenId) external payable returns (bool);
+
     function deleteObject(
         uint256 tokenId,
         uint256 callbackGasLimit,

--- a/contracts/middle-layer/resource-mirror/AdditionalBucketHub.sol
+++ b/contracts/middle-layer/resource-mirror/AdditionalBucketHub.sol
@@ -6,7 +6,7 @@ import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 import "@openzeppelin/contracts-upgradeable/utils/structs/DoubleEndedQueueUpgradeable.sol";
 
 import "./storage/BucketStorage.sol";
-import "./utils/AccessControl.sol";
+import "./utils/GnfdAccessControl.sol";
 import "../../interface/IApplication.sol";
 import "../../interface/ICrossChain.sol";
 import "../../interface/IERC721NonTransferable.sol";
@@ -15,7 +15,7 @@ import "../../interface/IERC721NonTransferable.sol";
 // which means same state variables and same order of state variables.
 // Because it will be used as a delegate call target.
 // NOTE: The inherited contracts order must be the same as BucketHub.
-contract AdditionalBucketHub is BucketStorage, AccessControl {
+contract AdditionalBucketHub is BucketStorage, GnfdAccessControl {
     using DoubleEndedQueueUpgradeable for DoubleEndedQueueUpgradeable.Bytes32Deque;
 
     /*----------------- external function -----------------*/

--- a/contracts/middle-layer/resource-mirror/AdditionalGroupHub.sol
+++ b/contracts/middle-layer/resource-mirror/AdditionalGroupHub.sol
@@ -6,7 +6,7 @@ import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 import "@openzeppelin/contracts-upgradeable/utils/structs/DoubleEndedQueueUpgradeable.sol";
 
 import "./storage/GroupStorage.sol";
-import "./utils/AccessControl.sol";
+import "./utils/GnfdAccessControl.sol";
 import "../../interface/IApplication.sol";
 import "../../interface/ICrossChain.sol";
 import "../../interface/IERC721NonTransferable.sol";
@@ -15,7 +15,7 @@ import "../../interface/IERC721NonTransferable.sol";
 // which means same state variables and same order of state variables.
 // Because it will be used as a delegate call target.
 // NOTE: The inherited contracts order must be the same as GroupHub.
-contract AdditionalGroupHub is GroupStorage, AccessControl {
+contract AdditionalGroupHub is GroupStorage, GnfdAccessControl {
     using DoubleEndedQueueUpgradeable for DoubleEndedQueueUpgradeable.Bytes32Deque;
 
     /*----------------- external function -----------------*/

--- a/contracts/middle-layer/resource-mirror/AdditionalObjectHub.sol
+++ b/contracts/middle-layer/resource-mirror/AdditionalObjectHub.sol
@@ -6,7 +6,7 @@ import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 import "@openzeppelin/contracts-upgradeable/utils/structs/DoubleEndedQueueUpgradeable.sol";
 
 import "./storage/ObjectStorage.sol";
-import "./utils/AccessControl.sol";
+import "./utils/GnfdAccessControl.sol";
 import "../../interface/IApplication.sol";
 import "../../interface/ICrossChain.sol";
 import "../../interface/IERC721NonTransferable.sol";
@@ -15,7 +15,7 @@ import "../../interface/IERC721NonTransferable.sol";
 // which means same state variables and same order of state variables.
 // Because it will be used as a delegate call target.
 // NOTE: The inherited contracts order must be the same as ObjectHub.
-contract AdditionalObjectHub is ObjectStorage, AccessControl {
+contract AdditionalObjectHub is ObjectStorage, GnfdAccessControl {
     using DoubleEndedQueueUpgradeable for DoubleEndedQueueUpgradeable.Bytes32Deque;
 
     /*----------------- external function -----------------*/

--- a/contracts/middle-layer/resource-mirror/BucketHub.sol
+++ b/contracts/middle-layer/resource-mirror/BucketHub.sol
@@ -5,11 +5,11 @@ pragma solidity ^0.8.0;
 import "@openzeppelin/contracts-upgradeable/utils/structs/DoubleEndedQueueUpgradeable.sol";
 
 import "./CmnHub.sol";
-import "./utils/AccessControl.sol";
+import "./utils/GnfdAccessControl.sol";
 import "../../interface/IBucketHub.sol";
 import "../../interface/IERC721NonTransferable.sol";
 
-contract BucketHub is BucketStorage, AccessControl, CmnHub, IBucketHub {
+contract BucketHub is BucketStorage, GnfdAccessControl, CmnHub, IBucketHub {
     using DoubleEndedQueueUpgradeable for DoubleEndedQueueUpgradeable.Bytes32Deque;
 
     function initialize(address _ERC721_token, address _additional) public initializer {

--- a/contracts/middle-layer/resource-mirror/GroupHub.sol
+++ b/contracts/middle-layer/resource-mirror/GroupHub.sol
@@ -5,12 +5,12 @@ pragma solidity ^0.8.0;
 import "@openzeppelin/contracts-upgradeable/utils/structs/DoubleEndedQueueUpgradeable.sol";
 
 import "./CmnHub.sol";
-import "./utils/AccessControl.sol";
+import "./utils/GnfdAccessControl.sol";
 import "../../interface/IERC1155NonTransferable.sol";
 import "../../interface/IERC721NonTransferable.sol";
 import "../../interface/IGroupHub.sol";
 
-contract GroupHub is GroupStorage, AccessControl, CmnHub, IGroupHub {
+contract GroupHub is GroupStorage, GnfdAccessControl, CmnHub, IGroupHub {
     using DoubleEndedQueueUpgradeable for DoubleEndedQueueUpgradeable.Bytes32Deque;
 
     function initialize(address _ERC721_token, address _ERC1155_token, address _additional) public initializer {

--- a/contracts/middle-layer/resource-mirror/ObjectHub.sol
+++ b/contracts/middle-layer/resource-mirror/ObjectHub.sol
@@ -5,11 +5,11 @@ pragma solidity ^0.8.0;
 import "@openzeppelin/contracts-upgradeable/utils/structs/DoubleEndedQueueUpgradeable.sol";
 
 import "./CmnHub.sol";
-import "./utils/AccessControl.sol";
+import "./utils/GnfdAccessControl.sol";
 import "../../interface/IERC721NonTransferable.sol";
 import "../../interface/IObjectHub.sol";
 
-contract ObjectHub is ObjectStorage, AccessControl, CmnHub, IObjectHub {
+contract ObjectHub is ObjectStorage, GnfdAccessControl, CmnHub, IObjectHub {
     using DoubleEndedQueueUpgradeable for DoubleEndedQueueUpgradeable.Bytes32Deque;
 
     function initialize(address _ERC721_token, address _additional) public initializer {

--- a/contracts/middle-layer/resource-mirror/utils/GnfdAccessControl.sol
+++ b/contracts/middle-layer/resource-mirror/utils/GnfdAccessControl.sol
@@ -5,9 +5,9 @@ pragma solidity ^0.8.0;
 import "@openzeppelin/contracts/utils/Context.sol";
 import "@openzeppelin/contracts/utils/Strings.sol";
 
-import "../../../interface/IAccessControl.sol";
+import "../../../interface/IGnfdAccessControl.sol";
 
-contract AccessControl is Context, IAccessControl {
+contract GnfdAccessControl is Context, IGnfdAccessControl {
     // Role => Granter => Operator => ExpireTime
     mapping(bytes32 => mapping(address => mapping(address => uint256))) private _roles;
 
@@ -20,7 +20,7 @@ contract AccessControl is Context, IAccessControl {
      *
      * The format of the revert reason is given by the following regular expression:
      *
-     *  /^AccessControl: account (0x[0-9a-f]{40}) is missing grant
+     *  /^GnfdAccessControl: account (0x[0-9a-f]{40}) is missing grant
      * from (0x[0-9a-f]{40}) as role (0x[0-9a-f]{64})$/
      */
     modifier onlyRole(bytes32 role, address granter) {
@@ -44,7 +44,7 @@ contract AccessControl is Context, IAccessControl {
      * May emit a {RoleGranted} event.
      */
     function grantRole(bytes32 role, address grantee, uint256 expireTime) public virtual {
-        require(expireTime > block.timestamp, "AccessControl: Expire time must be greater than current time");
+        require(expireTime > block.timestamp, "GnfdAccessControl: Expire time must be greater than current time");
         _grantRole(role, _msgSender(), grantee, expireTime);
     }
 
@@ -103,7 +103,7 @@ contract AccessControl is Context, IAccessControl {
      *
      * The format of the revert reason is given by the following regular expression:
      *
-     *  /^AccessControl: account (0x[0-9a-f]{40}) is missing grant
+     *  /^GnfdAccessControl: account (0x[0-9a-f]{40}) is missing grant
      * from (0x[0-9a-f]{40}) as role (0x[0-9a-f]{64})$/
      */
     function _checkRole(bytes32 role, address granter, address operator) internal view virtual {
@@ -111,7 +111,7 @@ contract AccessControl is Context, IAccessControl {
             revert(
                 string(
                     abi.encodePacked(
-                        "AccessControl: account ",
+                        "GnfdAccessControl: account ",
                         Strings.toHexString(operator),
                         " is missing grant from ",
                         Strings.toHexString(granter),


### PR DESCRIPTION
### Description

This pr is to rename `AccessControl` to `GnfdAccessControl`.

### Rationale

To avoid naming conflicts with @openzeppelin AccessControl contract.

### Changes

Notable changes:
* rename `AccessControl` to `GnfdAccessControl`