### PR TITLE
chore: refactor `IERC721NonTransferable` and `IERC1155NonTransferable`

### DIFF
--- a/contracts/interface/IERC1155NonTransferable.sol
+++ b/contracts/interface/IERC1155NonTransferable.sol
@@ -2,30 +2,14 @@
 
 pragma solidity ^0.8.0;
 
+import "@openzeppelin/contracts/token/ERC1155/IERC1155.sol";
+
 /**
  * @dev External interface of ERC1155NonTransferable declared to support ERC165 detection.
  *
- * This multi-token doesn't support token transfer or approval.
+ * This multi-token DOESN'T support token transfer or approval.
  */
-interface IERC1155NonTransferable {
-    event TransferSingle(address indexed operator, address indexed from, address indexed to, uint256 id, uint256 value);
-    event TransferBatch(
-        address indexed operator,
-        address indexed from,
-        address indexed to,
-        uint256[] ids,
-        uint256[] values
-    );
-    event ApprovalForAll(address indexed account, address indexed operator, bool approved);
-    event URI(string value, uint256 indexed id);
-
-    function balanceOf(address account, uint256 id) external view returns (uint256);
-
-    function balanceOfBatch(
-        address[] calldata accounts,
-        uint256[] calldata ids
-    ) external view returns (uint256[] memory);
-
+interface IERC1155NonTransferable is IERC1155 {
     function baseURI() external view returns (string memory);
 
     function uri(uint256 id) external view returns (string memory);

--- a/contracts/interface/IERC721NonTransferable.sol
+++ b/contracts/interface/IERC721NonTransferable.sol
@@ -1,42 +1,21 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
+import "@openzeppelin/contracts/token/ERC721/extensions/IERC721Enumerable.sol";
+import "@openzeppelin/contracts/token/ERC721/extensions/IERC721Metadata.sol";
+
 pragma solidity ^0.8.0;
 
 /**
  * @dev External interface of ERC721NonTransferable declared to support ERC165 detection.
  *
- * This Non-Fungible Token doesn't support token transfer or approval.
+ * This Non-Fungible Token DOESN'T support token transfer or approval.
  */
-interface IERC721NonTransferable {
-    event Transfer(address indexed from, address indexed to, uint256 indexed tokenId);
-    event Approval(address indexed owner, address indexed approved, uint256 indexed tokenId);
-    event ApprovalForAll(address indexed owner, address indexed operator, bool approved);
-
-    function name() external view returns (string memory);
-
-    function symbol() external view returns (string memory);
-
-    function balanceOf(address owner) external view returns (uint256 balance);
-
-    function ownerOf(uint256 tokenId) external view returns (address owner);
-
+interface IERC721NonTransferable is IERC721Enumerable {
     function exists(uint256 tokenId) external view returns (bool);
-
-    function tokenURI(uint256 tokenId) external view returns (string memory);
 
     function setBaseURI(string calldata newURI) external;
 
     function mint(address to, uint256 tokenId) external;
 
     function burn(uint256 tokenId) external;
-
-    function getApproved(uint256 tokenId) external view returns (address operator);
-
-    function isApprovedForAll(address owner, address operator) external view returns (bool);
-
-    function totalSupply() external view returns (uint256);
-
-    function tokenOfOwnerByIndex(address owner, uint256 index) external view returns (uint256);
-
-    function tokenByIndex(uint256 index) external view returns (uint256);
 }

--- a/contracts/tokens/ERC1155NonTransferable.sol
+++ b/contracts/tokens/ERC1155NonTransferable.sol
@@ -4,12 +4,11 @@ pragma solidity ^0.8.0;
 
 import "@openzeppelin/contracts/utils/Address.sol";
 import "@openzeppelin/contracts/utils/Context.sol";
-import "@openzeppelin/contracts/utils/introspection/ERC165.sol";
 import "@openzeppelin/contracts/token/ERC1155/IERC1155Receiver.sol";
 
 import "../interface/IERC1155NonTransferable.sol";
 
-contract ERC1155NonTransferable is Context, ERC165, IERC1155NonTransferable {
+contract ERC1155NonTransferable is Context, IERC1155NonTransferable {
     using Address for address;
 
     address private _controlHub;
@@ -73,8 +72,8 @@ contract ERC1155NonTransferable is Context, ERC165, IERC1155NonTransferable {
     /**
      * @dev See {IERC165-supportsInterface}.
      */
-    function supportsInterface(bytes4 interfaceId) public view override returns (bool) {
-        return interfaceId == type(IERC1155NonTransferable).interfaceId || super.supportsInterface(interfaceId);
+    function supportsInterface(bytes4 interfaceId) public pure override returns (bool) {
+        return interfaceId == type(IERC1155NonTransferable).interfaceId;
     }
 
     function baseURI() public view returns (string memory) {

--- a/contracts/tokens/ERC721NonTransferable.sol
+++ b/contracts/tokens/ERC721NonTransferable.sol
@@ -5,12 +5,11 @@ pragma solidity ^0.8.0;
 import "@openzeppelin/contracts/utils/Address.sol";
 import "@openzeppelin/contracts/utils/Context.sol";
 import "@openzeppelin/contracts/utils/Strings.sol";
-import "@openzeppelin/contracts/utils/introspection/ERC165.sol";
 import "@openzeppelin/contracts/token/ERC721/IERC721Receiver.sol";
 
 import "../interface/IERC721NonTransferable.sol";
 
-contract ERC721NonTransferable is Context, ERC165, IERC721NonTransferable {
+contract ERC721NonTransferable is Context, IERC721NonTransferable, IERC721Metadata {
     using Address for address;
     using Strings for uint256;
 
@@ -122,8 +121,9 @@ contract ERC721NonTransferable is Context, ERC165, IERC721NonTransferable {
     /**
      * @dev See {IERC165-supportsInterface}.
      */
-    function supportsInterface(bytes4 interfaceId) public view override returns (bool) {
-        return interfaceId == type(IERC721NonTransferable).interfaceId || super.supportsInterface(interfaceId);
+    function supportsInterface(bytes4 interfaceId) public pure override returns (bool) {
+        return
+            interfaceId == type(IERC721NonTransferable).interfaceId || interfaceId == type(IERC721Metadata).interfaceId;
     }
 
     /**


### PR DESCRIPTION
### Description

This pr is to refactor `IERC721NonTransferable` and `IERC1155NonTransferable` interfaces to make it more standard. 

### Changes

Notable changes:
* refactor `IERC721NonTransferable` and `IERC1155NonTransferable`