### PR TITLE
fix: add missing transfer from resource-mirror contracts to tokenHub contract

### DIFF
--- a/contracts/middle-layer/resource-mirror/AdditionalBucketHub.sol
+++ b/contracts/middle-layer/resource-mirror/AdditionalBucketHub.sol
@@ -88,6 +88,11 @@ contract AdditionalBucketHub is BucketStorage, GnfdAccessControl {
             relayFee,
             _ackRelayFee
         );
+
+        // transfer all the fee to tokenHub
+        (bool success, ) = TOKEN_HUB.call{value: address(this).balance}("");
+        require(success, "transfer to tokenHub failed");
+
         emit CreateSubmitted(owner, msg.sender, synPkg.name);
         return true;
     }
@@ -137,6 +142,11 @@ contract AdditionalBucketHub is BucketStorage, GnfdAccessControl {
             relayFee,
             _ackRelayFee
         );
+
+        // transfer all the fee to tokenHub
+        (success, ) = TOKEN_HUB.call{value: address(this).balance}("");
+        require(success, "transfer to tokenHub failed");
+
         emit CreateSubmitted(owner, msg.sender, synPkg.name);
         return true;
     }
@@ -170,6 +180,11 @@ contract AdditionalBucketHub is BucketStorage, GnfdAccessControl {
             relayFee,
             _ackRelayFee
         );
+
+        // transfer all the fee to tokenHub
+        (bool success, ) = TOKEN_HUB.call{value: address(this).balance}("");
+        require(success, "transfer to tokenHub failed");
+
         emit DeleteSubmitted(owner, msg.sender, id);
         return true;
     }
@@ -227,6 +242,11 @@ contract AdditionalBucketHub is BucketStorage, GnfdAccessControl {
             relayFee,
             _ackRelayFee
         );
+
+        // transfer all the fee to tokenHub
+        (success, ) = TOKEN_HUB.call{value: address(this).balance}("");
+        require(success, "transfer to tokenHub failed");
+
         emit DeleteSubmitted(owner, msg.sender, id);
         return true;
     }

--- a/contracts/middle-layer/resource-mirror/AdditionalBucketHub.sol
+++ b/contracts/middle-layer/resource-mirror/AdditionalBucketHub.sol
@@ -90,7 +90,7 @@ contract AdditionalBucketHub is BucketStorage, GnfdAccessControl {
         );
 
         // transfer all the fee to tokenHub
-        (bool success, ) = TOKEN_HUB.call{value: address(this).balance}("");
+        (bool success, ) = TOKEN_HUB.call{ value: address(this).balance }("");
         require(success, "transfer to tokenHub failed");
 
         emit CreateSubmitted(owner, msg.sender, synPkg.name);
@@ -144,7 +144,7 @@ contract AdditionalBucketHub is BucketStorage, GnfdAccessControl {
         );
 
         // transfer all the fee to tokenHub
-        (success, ) = TOKEN_HUB.call{value: address(this).balance}("");
+        (success, ) = TOKEN_HUB.call{ value: address(this).balance }("");
         require(success, "transfer to tokenHub failed");
 
         emit CreateSubmitted(owner, msg.sender, synPkg.name);
@@ -182,7 +182,7 @@ contract AdditionalBucketHub is BucketStorage, GnfdAccessControl {
         );
 
         // transfer all the fee to tokenHub
-        (bool success, ) = TOKEN_HUB.call{value: address(this).balance}("");
+        (bool success, ) = TOKEN_HUB.call{ value: address(this).balance }("");
         require(success, "transfer to tokenHub failed");
 
         emit DeleteSubmitted(owner, msg.sender, id);
@@ -244,7 +244,7 @@ contract AdditionalBucketHub is BucketStorage, GnfdAccessControl {
         );
 
         // transfer all the fee to tokenHub
-        (success, ) = TOKEN_HUB.call{value: address(this).balance}("");
+        (success, ) = TOKEN_HUB.call{ value: address(this).balance }("");
         require(success, "transfer to tokenHub failed");
 
         emit DeleteSubmitted(owner, msg.sender, id);

--- a/contracts/middle-layer/resource-mirror/AdditionalGroupHub.sol
+++ b/contracts/middle-layer/resource-mirror/AdditionalGroupHub.sol
@@ -98,7 +98,7 @@ contract AdditionalGroupHub is GroupStorage, GnfdAccessControl {
         );
 
         // transfer all the fee to tokenHub
-        (bool success, ) = TOKEN_HUB.call{value: address(this).balance}("");
+        (bool success, ) = TOKEN_HUB.call{ value: address(this).balance }("");
         require(success, "transfer to tokenHub failed");
 
         emit CreateSubmitted(owner, msg.sender, name);
@@ -157,7 +157,7 @@ contract AdditionalGroupHub is GroupStorage, GnfdAccessControl {
         );
 
         // transfer all the fee to tokenHub
-        (success, ) = TOKEN_HUB.call{value: address(this).balance}("");
+        (success, ) = TOKEN_HUB.call{ value: address(this).balance }("");
         require(success, "transfer to tokenHub failed");
 
         emit CreateSubmitted(owner, msg.sender, name);
@@ -196,7 +196,7 @@ contract AdditionalGroupHub is GroupStorage, GnfdAccessControl {
         );
 
         // transfer all the fee to tokenHub
-        (bool success, ) = TOKEN_HUB.call{value: address(this).balance}("");
+        (bool success, ) = TOKEN_HUB.call{ value: address(this).balance }("");
         require(success, "transfer to tokenHub failed");
 
         emit DeleteSubmitted(owner, msg.sender, id);
@@ -258,7 +258,7 @@ contract AdditionalGroupHub is GroupStorage, GnfdAccessControl {
         );
 
         // transfer all the fee to tokenHub
-        (success, ) = TOKEN_HUB.call{value: address(this).balance}("");
+        (success, ) = TOKEN_HUB.call{ value: address(this).balance }("");
         require(success, "transfer to tokenHub failed");
 
         emit DeleteSubmitted(owner, msg.sender, id);
@@ -297,7 +297,7 @@ contract AdditionalGroupHub is GroupStorage, GnfdAccessControl {
         );
 
         // transfer all the fee to tokenHub
-        (bool success, ) = TOKEN_HUB.call{value: address(this).balance}("");
+        (bool success, ) = TOKEN_HUB.call{ value: address(this).balance }("");
         require(success, "transfer to tokenHub failed");
 
         emit UpdateSubmitted(owner, msg.sender, synPkg.id, uint8(synPkg.opType), synPkg.members);
@@ -355,7 +355,7 @@ contract AdditionalGroupHub is GroupStorage, GnfdAccessControl {
         );
 
         // transfer all the fee to tokenHub
-        (success, ) = TOKEN_HUB.call{value: address(this).balance}("");
+        (success, ) = TOKEN_HUB.call{ value: address(this).balance }("");
         require(success, "transfer to tokenHub failed");
 
         emit UpdateSubmitted(owner, msg.sender, synPkg.id, uint8(synPkg.opType), synPkg.members);

--- a/contracts/middle-layer/resource-mirror/AdditionalGroupHub.sol
+++ b/contracts/middle-layer/resource-mirror/AdditionalGroupHub.sol
@@ -96,6 +96,11 @@ contract AdditionalGroupHub is GroupStorage, GnfdAccessControl {
             relayFee,
             _ackRelayFee
         );
+
+        // transfer all the fee to tokenHub
+        (bool success, ) = TOKEN_HUB.call{value: address(this).balance}("");
+        require(success, "transfer to tokenHub failed");
+
         emit CreateSubmitted(owner, msg.sender, name);
         return true;
     }
@@ -150,6 +155,11 @@ contract AdditionalGroupHub is GroupStorage, GnfdAccessControl {
             relayFee,
             _ackRelayFee
         );
+
+        // transfer all the fee to tokenHub
+        (success, ) = TOKEN_HUB.call{value: address(this).balance}("");
+        require(success, "transfer to tokenHub failed");
+
         emit CreateSubmitted(owner, msg.sender, name);
         return true;
     }
@@ -184,6 +194,11 @@ contract AdditionalGroupHub is GroupStorage, GnfdAccessControl {
             relayFee,
             _ackRelayFee
         );
+
+        // transfer all the fee to tokenHub
+        (bool success, ) = TOKEN_HUB.call{value: address(this).balance}("");
+        require(success, "transfer to tokenHub failed");
+
         emit DeleteSubmitted(owner, msg.sender, id);
         return true;
     }
@@ -241,6 +256,11 @@ contract AdditionalGroupHub is GroupStorage, GnfdAccessControl {
             relayFee,
             _ackRelayFee
         );
+
+        // transfer all the fee to tokenHub
+        (success, ) = TOKEN_HUB.call{value: address(this).balance}("");
+        require(success, "transfer to tokenHub failed");
+
         emit DeleteSubmitted(owner, msg.sender, id);
         return true;
     }
@@ -275,6 +295,11 @@ contract AdditionalGroupHub is GroupStorage, GnfdAccessControl {
             relayFee,
             _ackRelayFee
         );
+
+        // transfer all the fee to tokenHub
+        (bool success, ) = TOKEN_HUB.call{value: address(this).balance}("");
+        require(success, "transfer to tokenHub failed");
+
         emit UpdateSubmitted(owner, msg.sender, synPkg.id, uint8(synPkg.opType), synPkg.members);
         return true;
     }
@@ -328,6 +353,11 @@ contract AdditionalGroupHub is GroupStorage, GnfdAccessControl {
             relayFee,
             _ackRelayFee
         );
+
+        // transfer all the fee to tokenHub
+        (success, ) = TOKEN_HUB.call{value: address(this).balance}("");
+        require(success, "transfer to tokenHub failed");
+
         emit UpdateSubmitted(owner, msg.sender, synPkg.id, uint8(synPkg.opType), synPkg.members);
         return true;
     }

--- a/contracts/middle-layer/resource-mirror/AdditionalObjectHub.sol
+++ b/contracts/middle-layer/resource-mirror/AdditionalObjectHub.sol
@@ -84,6 +84,11 @@ contract AdditionalObjectHub is ObjectStorage, GnfdAccessControl {
             relayFee,
             _ackRelayFee
         );
+
+        // transfer all the fee to tokenHub
+        (bool success, ) = TOKEN_HUB.call{value: address(this).balance}("");
+        require(success, "transfer to tokenHub failed");
+
         emit DeleteSubmitted(owner, msg.sender, id);
         return true;
     }
@@ -141,6 +146,11 @@ contract AdditionalObjectHub is ObjectStorage, GnfdAccessControl {
             relayFee,
             _ackRelayFee
         );
+
+        // transfer all the fee to tokenHub
+        (success, ) = TOKEN_HUB.call{value: address(this).balance}("");
+        require(success, "transfer to tokenHub failed");
+
         emit DeleteSubmitted(owner, msg.sender, id);
         return true;
     }

--- a/contracts/middle-layer/resource-mirror/AdditionalObjectHub.sol
+++ b/contracts/middle-layer/resource-mirror/AdditionalObjectHub.sol
@@ -86,7 +86,7 @@ contract AdditionalObjectHub is ObjectStorage, GnfdAccessControl {
         );
 
         // transfer all the fee to tokenHub
-        (bool success, ) = TOKEN_HUB.call{value: address(this).balance}("");
+        (bool success, ) = TOKEN_HUB.call{ value: address(this).balance }("");
         require(success, "transfer to tokenHub failed");
 
         emit DeleteSubmitted(owner, msg.sender, id);
@@ -148,7 +148,7 @@ contract AdditionalObjectHub is ObjectStorage, GnfdAccessControl {
         );
 
         // transfer all the fee to tokenHub
-        (success, ) = TOKEN_HUB.call{value: address(this).balance}("");
+        (success, ) = TOKEN_HUB.call{ value: address(this).balance }("");
         require(success, "transfer to tokenHub failed");
 
         emit DeleteSubmitted(owner, msg.sender, id);


### PR DESCRIPTION
### Description

This pr is to fix error that resource-mirror contracts do not transfer msg.value to the tokenHub contract

### Changes

Notable changes:
* add missing transfer