### PR TITLE
feat: add emergency operator for GovHub

### DIFF
--- a/contracts/Config.sol
+++ b/contracts/Config.sol
@@ -23,6 +23,7 @@ abstract contract Config {
     address public constant BUCKET_HUB = address(0);
     address public constant OBJECT_HUB = address(0);
     address public constant GROUP_HUB = address(0);
+    address public constant EMERGENCY_OPERATOR = address(0);
 
     // PlaceHolder reserve for future usage
     uint256[50] public ConfigSlots;
@@ -34,6 +35,11 @@ abstract contract Config {
 
     modifier onlyGov() {
         require(msg.sender == GOV_HUB, "only GovHub contract");
+        _;
+    }
+
+    modifier onlyEmergencyOperator() {
+        require(msg.sender == EMERGENCY_OPERATOR, "only Emergency Operator");
         _;
     }
 

--- a/contracts/CrossChain.sol
+++ b/contracts/CrossChain.sol
@@ -331,6 +331,10 @@ contract CrossChain is Config, Initializable, ICrossChain {
         }
     }
 
+    function emergencyCancelTransfer(address attacker) external onlyEmergencyOperator {
+        ITokenHub(TOKEN_HUB).cancelTransferIn(attacker);
+    }
+
     function updateParam(string calldata key, bytes calldata value) external onlyGov whenNotSuspended {
         uint256 valueLength = value.length;
         if (_compareStrings(key, "relayFee")) {

--- a/contracts/middle-layer/GovHub.sol
+++ b/contracts/middle-layer/GovHub.sol
@@ -73,6 +73,15 @@ contract GovHub is Config, Initializable, IMiddleLayer {
         revert("receive unexpected fail ack package");
     }
 
+    function emergencyUpdate(
+        string memory key,
+        bytes memory values,
+        bytes memory targets
+    ) external onlyEmergencyOperator {
+        ParamChangePackage memory _proposal = ParamChangePackage(key, values, targets);
+        _notifyUpdates(_proposal);
+    }
+
     function _notifyUpdates(ParamChangePackage memory proposal) internal returns (uint32) {
         require(proposal.targets.length > 0 && proposal.targets.length % 20 == 0, "invalid target length");
         uint256 totalTargets = proposal.targets.length / 20;

--- a/contracts/test/GnfdLightClientTest.sol
+++ b/contracts/test/GnfdLightClientTest.sol
@@ -285,7 +285,7 @@ contract GnfdLightClientTest is Initializable, Config, ILightClient {
         override
         returns (uint256 version, string memory name, string memory description)
     {
-        return (400_001, "GnfdLightClient", "init version");
+        return (400_002, "GnfdLightClient", "upgrade version");
     }
 
     function updateParam(string calldata key, bytes calldata value) external onlyGov {

--- a/foundry-scripts/EmergencyOperator.s.sol
+++ b/foundry-scripts/EmergencyOperator.s.sol
@@ -1,0 +1,53 @@
+pragma solidity ^0.8.0;
+
+import "./Helper.sol";
+contract EmergencyOperatorScript is Helper {
+
+    struct ParamChangePackage {
+        string key;
+        bytes values;
+        bytes targets;
+    }
+
+    function generateEmergencyUpgrade(address target, address newImpl) external view {
+        string memory key = "upgrade";
+        bytes memory values = abi.encodePacked(newImpl);
+        bytes memory targets = abi.encodePacked(target);
+
+        console.log("key", key);
+
+        console.log("values: ");
+        console.logBytes(values);
+
+        console.log("targets: ");
+        console.logBytes(targets);
+    }
+
+    function generateEmergencyUpgrades(address[] memory _targets, address[] memory _newImpls) external view {
+        string memory key = "upgrade";
+        bytes memory values = abi.encodePacked(_newImpls);
+        bytes memory targets = abi.encodePacked(_targets);
+
+        console.log("key", key);
+
+        console.log("values: ");
+        console.logBytes(values);
+
+        console.log("targets: ");
+        console.logBytes(targets);
+    }
+
+    function generateEmergencyUpdateParam(string memory key, address target, uint256 newValue) external view {
+        bytes memory values = abi.encodePacked(newValue);
+        bytes memory targets = abi.encodePacked(target);
+
+        console.log("key", key);
+
+        console.log("values: ");
+        console.logBytes(values);
+
+        console.log("targets: ");
+        console.logBytes(targets);
+    }
+
+}

--- a/foundry-scripts/examples/emergencyOperator.sh
+++ b/foundry-scripts/examples/emergencyOperator.sh
@@ -1,0 +1,24 @@
+# 1. generate EmergencyUpgrade params
+# set target contract and new implement contract
+forge script foundry-scripts/EmergencyOperator.s.sol:EmergencyOperatorScript \
+--sig "generateEmergencyUpgrade(address target, address newImpl)" \
+${the target contract} ${new implement for the target} \
+-f https://data-seed-prebsc-1-s1.binance.org:8545/ \
+--legacy --ffi
+
+# 2. generate EmergencyUpgrade contracts params
+# set target contracts and new implement contracts
+forge script foundry-scripts/EmergencyOperator.s.sol:EmergencyOperatorScript \
+--sig "generateEmergencyUpgrades(address[] memory _targets, address[] memory _newImpls)" \
+${the target contracts separated by commas} ${new implements separated by commas} \
+-f https://data-seed-prebsc-1-s1.binance.org:8545/ \
+--legacy --ffi
+
+# 3. generate Emergency UpdateParam
+# set key, target contract and new value
+forge script foundry-scripts/EmergencyOperator.s.sol:EmergencyOperatorScript \
+--sig "generateEmergencyUpdateParam(string memory key, address target, uint256 newValue)" \
+${the param key} ${the target contract} ${new value for param} \
+-f https://data-seed-prebsc-1-s1.binance.org:8545/ \
+--legacy --ffi
+

--- a/foundry-tests/GovHub.t.sol
+++ b/foundry-tests/GovHub.t.sol
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+pragma solidity ^0.8.0;
+
+import "forge-std/Test.sol";
+
+import "contracts/CrossChain.sol";
+import "contracts/middle-layer/GovHub.sol";
+import "contracts/middle-layer/resource-mirror/BucketHub.sol";
+import "contracts/tokens/ERC721NonTransferable.sol";
+import "../contracts/test/GnfdLightClientTest.sol";
+
+contract GovHubTest is Test, GovHub {
+    event Transfer(address indexed from, address indexed to, uint256 indexed tokenId);
+    event GreenfieldCall(
+        uint32 indexed status,
+        uint8 channelId,
+        uint8 indexed operationType,
+        uint256 indexed resourceId,
+        bytes callbackData
+    );
+
+    ERC721NonTransferable public bucketToken;
+    GovHub public govHub;
+    CrossChain public crossChain;
+
+    receive() external payable {}
+
+    function setUp() public {
+        vm.createSelectFork("local");
+
+        govHub = GovHub(GOV_HUB);
+        crossChain = CrossChain(CROSS_CHAIN);
+
+        vm.label(GOV_HUB, "govHub");
+        vm.label(CROSS_CHAIN, "crossChain");
+    }
+
+    function test_gov_correct_case_1() public {
+        ParamChangePackage memory proposal = ParamChangePackage({
+            key: "BaseURI",
+            values: bytes("newBucket"),
+            targets: abi.encodePacked(BUCKET_HUB)
+        });
+        bytes memory msgBytes = _encodeGovSynPackage(proposal);
+
+        vm.expectEmit(true, true, false, true, BUCKET_HUB);
+        emit ParamChange("BaseURI", bytes("newBucket"));
+        vm.prank(CROSS_CHAIN);
+        govHub.handleSynPackage(GOV_CHANNEL_ID, msgBytes);
+    }
+
+    function test_gov_correct_case_2() public {
+        ParamChangePackage memory proposal = ParamChangePackage({
+            key: "BaseURI",
+            values: bytes("newBucket"),
+            targets: abi.encodePacked(BUCKET_HUB)
+        });
+
+        vm.expectEmit(true, true, false, true, BUCKET_HUB);
+        emit ParamChange("BaseURI", bytes("newBucket"));
+        vm.prank(EMERGENCY_OPERATOR);
+        govHub.emergencyUpdate(proposal.key, proposal.values, proposal.targets);
+    }
+
+    function test_gov_correct_case_3() public {
+        address _newLightClient = address(new GnfdLightClientTest());
+        ParamChangePackage memory proposal = ParamChangePackage({
+            key: "upgrade",
+            values: abi.encodePacked(_newLightClient),
+            targets: abi.encodePacked(LIGHT_CLIENT)
+        });
+
+        vm.expectEmit(true, true, true, true, GOV_HUB);
+        emit SuccessUpgrade(LIGHT_CLIENT, _newLightClient);
+        vm.prank(EMERGENCY_OPERATOR);
+        govHub.emergencyUpdate(proposal.key, proposal.values, proposal.targets);
+    }
+
+    function test_gov_error_case_1() public {
+        ParamChangePackage memory proposal = ParamChangePackage({
+            key: "BaseURI",
+            values: bytes("newBucket"),
+            targets: abi.encodePacked(BUCKET_HUB)
+        });
+
+        vm.expectRevert("only Emergency Operator");
+        govHub.emergencyUpdate(proposal.key, proposal.values, proposal.targets);
+    }
+
+    function _encodeGovSynPackage(ParamChangePackage memory proposal) internal pure returns (bytes memory) {
+        return abi.encode(proposal);
+    }
+
+}

--- a/scripts/1-deploy.ts
+++ b/scripts/1-deploy.ts
@@ -70,7 +70,9 @@ const main = async () => {
             throw new Error('emergencyOperator is not multi-sig contract');
         }
     } else { // BSC Testnet
-        emergencyOperator = operator.address
+        if (!emergencyOperator) {
+            emergencyOperator = operator.address
+        }
     }
 
     log('emergencyOperator: ', emergencyOperator);

--- a/scripts/1-deploy.ts
+++ b/scripts/1-deploy.ts
@@ -9,6 +9,7 @@ const log = console.log;
 const unit = ethers.constants.WeiPerEther;
 
 const gnfdChainId = 9000;
+let emergencyOperator = ''
 const initConsensusState: any = {
     chainID: 'greenfield_9000-1741',
     height: 1,
@@ -58,6 +59,22 @@ const main = async () => {
     log('network', network);
     log('operator.address: ', operator.address, toHuman(balance));
 
+    // BSC Mainnet
+    if (network.chainId === 56) {
+        if (!emergencyOperator) {
+            throw new Error('emergencyOperator is not set');
+        }
+
+        const code = await ethers.provider.getCode(emergencyOperator);
+        if (code.length < 10) {
+            throw new Error('emergencyOperator is not multi-sig contract');
+        }
+    } else { // BSC Testnet
+        emergencyOperator = operator.address
+    }
+
+    log('emergencyOperator: ', emergencyOperator);
+
     execSync('npx hardhat compile');
     await sleep(2);
 
@@ -86,7 +103,8 @@ const main = async () => {
         .replace(/RELAYER_HUB = .*/g, `RELAYER_HUB = ${proxyRelayerHub};`)
         .replace(/BUCKET_HUB = .*/g, `BUCKET_HUB = ${proxyBucketHub};`)
         .replace(/OBJECT_HUB = .*/g, `OBJECT_HUB = ${proxyObjectHub};`)
-        .replace(/GROUP_HUB = .*/g, `GROUP_HUB = ${proxyGroupHub};`);
+        .replace(/GROUP_HUB = .*/g, `GROUP_HUB = ${proxyGroupHub};`)
+        .replace(/EMERGENCY_OPERATOR = .*/g, `EMERGENCY_OPERATOR = ${emergencyOperator};`)
 
     log('Set all generated contracts to Config contracts');
 
@@ -185,6 +203,7 @@ const main = async () => {
         DeployCommitId: commitId,
         BlockNumber: blockNumber,
 
+        EmergencyOperator: emergencyOperator,
         Deployer: deployer.address,
 
         ProxyAdmin: proxyAdmin,


### PR DESCRIPTION
### Description

add emergency operator that update params in case of emergency

### Rationale

Ensure that multi-sig committee can upgrade contracts in time to protect cross-chain funds in case of emergency.

### Changes

Notable changes:
* add emergency operator in the Config contract
* add emergency operator in the deploy script
* add emergencyCancelTransfer in the CrossChain contract