### PR TITLE
feat: add emergency suspend/reopen for emergency operator

### DIFF
--- a/contracts/CrossChain.sol
+++ b/contracts/CrossChain.sol
@@ -335,6 +335,16 @@ contract CrossChain is Config, Initializable, ICrossChain {
         ITokenHub(TOKEN_HUB).cancelTransferIn(attacker);
     }
 
+    function emergencySuspend() external onlyEmergencyOperator whenNotSuspended {
+        isSuspended = true;
+        emit Suspended(msg.sender);
+    }
+
+    function emergencyReopen() external onlyEmergencyOperator whenSuspended {
+        isSuspended = false;
+        emit Reopened(msg.sender);
+    }
+
     function updateParam(string calldata key, bytes calldata value) external onlyGov whenNotSuspended {
         uint256 valueLength = value.length;
         if (_compareStrings(key, "relayFee")) {

--- a/contracts/middle-layer/GovHub.sol
+++ b/contracts/middle-layer/GovHub.sol
@@ -114,7 +114,10 @@ contract GovHub is Config, Initializable, IMiddleLayer {
                 require(Config(target).CROSS_CHAIN() == CROSS_CHAIN, "cross chain changed after upgrade");
                 require(Config(target).PROXY_ADMIN() == PROXY_ADMIN, "proxy admin changed after upgrade");
                 require(Config(target).GOV_HUB() == GOV_HUB, "gov hub changed after upgrade");
-                require(Config(target).EMERGENCY_OPERATOR() == EMERGENCY_OPERATOR, "emergency operator changed after upgrade");
+                require(
+                    Config(target).EMERGENCY_OPERATOR() == EMERGENCY_OPERATOR,
+                    "emergency operator changed after upgrade"
+                );
 
                 emit SuccessUpgrade(target, newImpl);
             }

--- a/foundry-scripts/EmergencyOperator.s.sol
+++ b/foundry-scripts/EmergencyOperator.s.sol
@@ -67,6 +67,27 @@ contract EmergencyOperatorScript is Helper {
         vm.stopBroadcast();
     }
 
+    function emergencySuspend() external {
+        // start broadcast real tx
+        vm.startBroadcast();
+        crossChain.emergencySuspend();
+        vm.stopBroadcast();
+    }
+
+    function emergencyReopen() external {
+        // start broadcast real tx
+        vm.startBroadcast();
+        crossChain.emergencyReopen();
+        vm.stopBroadcast();
+    }
+
+    function emergencyCancelTransfer(address attacker) external {
+        // start broadcast real tx
+        vm.startBroadcast();
+        crossChain.emergencyCancelTransfer(attacker);
+        vm.stopBroadcast();
+    }
+
     function _addressListToBytes(address[] memory _addresses) internal pure returns (bytes memory) {
         bytes memory result = new bytes(_addresses.length * 20);
         for (uint256 i = 0; i < _addresses.length; i++) {

--- a/foundry-scripts/examples/emergencyOperator.sh
+++ b/foundry-scripts/examples/emergencyOperator.sh
@@ -27,3 +27,24 @@ ${the param key} ${the target contract} ${new value for param} \
 -f https://data-seed-prebsc-1-s1.binance.org:8545/ \
 --legacy --ffi
 
+# 4. send emergencySuspend tx on testnet
+forge script foundry-scripts/EmergencyOperator.s.sol:EmergencyOperatorScript \
+--private-key ${your private key} \
+--sig "emergencySuspend()" \
+-f https://data-seed-prebsc-1-s1.binance.org:8545/ \
+--legacy --ffi --broadcast
+
+# 5. send emergencyReopen tx
+forge script foundry-scripts/EmergencyOperator.s.sol:EmergencyOperatorScript \
+--private-key ${your private key} \
+--sig "emergencyReopen()" \
+-f https://data-seed-prebsc-1-s1.binance.org:8545/ \
+--legacy --ffi --broadcast
+
+# 6. send emergencyCancelTransfer tx
+forge script foundry-scripts/EmergencyOperator.s.sol:EmergencyOperatorScript \
+--private-key ${your private key} \
+--sig "emergencyCancelTransfer(address attacker)" \
+${attacker address} \
+-f https://data-seed-prebsc-1-s1.binance.org:8545/ \
+--legacy --ffi --broadcast


### PR DESCRIPTION
### Description

add emergency suspend/reopen for emergency operator

### Rationale

for safety in emergency case

### Example
emergency suspend script: 
https://github.com/bnb-chain/greenfield-contracts/blob/f51f6e93020555ca81a8900252f63ac1920f2418/foundry-scripts/examples/emergencyOperator.sh#L30


### Changes

Notable changes:
* add emergency suspend/reopen for emergency operator
* add tests and sripts for emergency suspend/reopen
* ...