### PR TITLE
fix: add `globalVirtualGroupFamilyId` to `CreateBucketSynPackage`

### DIFF
--- a/contracts/middle-layer/resource-mirror/storage/BucketStorage.sol
+++ b/contracts/middle-layer/resource-mirror/storage/BucketStorage.sol
@@ -14,8 +14,9 @@ contract BucketStorage is CmnStorage {
         BucketVisibilityType visibility;
         address paymentAddress;
         address primarySpAddress;
-        uint256 primarySpApprovalExpiredHeight;
-        bytes primarySpSignature; // TODO if the owner of the bucket is a smart contract, we are not able to get the primarySpSignature
+        uint64 primarySpApprovalExpiredHeight;
+        uint32 globalVirtualGroupFamilyId;
+        bytes primarySpSignature;
         uint64 chargedReadQuota;
         bytes extraData; // abi.encode of ExtraData
     }

--- a/foundry-scripts/BucketHub.s.sol
+++ b/foundry-scripts/BucketHub.s.sol
@@ -8,7 +8,8 @@ contract BucketHubScript is Helper {
         uint8 bucketVisibilityType,
         address paymentAddress,
         address primarySpAddress,
-        uint256 primarySpApprovalExpiredHeight,
+        uint64 primarySpApprovalExpiredHeight,
+        uint32 globalVirtualGroupFamilyId,
         bytes memory primarySpSignature,
         uint64 chargedReadQuota
     ) external {
@@ -29,6 +30,7 @@ contract BucketHubScript is Helper {
             paymentAddress,
             primarySpAddress,
             primarySpApprovalExpiredHeight,
+            globalVirtualGroupFamilyId,
             primarySpSignature,
             chargedReadQuota,
             ""

--- a/foundry-tests/BucketHub.t.sol
+++ b/foundry-tests/BucketHub.t.sol
@@ -83,6 +83,7 @@ contract BucketHubTest is Test, BucketHub {
             paymentAddress: address(this),
             primarySpAddress: address(this),
             primarySpApprovalExpiredHeight: 0,
+            globalVirtualGroupFamilyId: 0,
             primarySpSignature: "",
             chargedReadQuota: 0,
             extraData: ""
@@ -130,6 +131,7 @@ contract BucketHubTest is Test, BucketHub {
             paymentAddress: address(this),
             primarySpAddress: address(this),
             primarySpApprovalExpiredHeight: 0,
+            globalVirtualGroupFamilyId: 0,
             primarySpSignature: "",
             chargedReadQuota: 0,
             extraData: ""
@@ -215,6 +217,7 @@ contract BucketHubTest is Test, BucketHub {
             paymentAddress: address(this),
             primarySpAddress: address(this),
             primarySpApprovalExpiredHeight: 0,
+            globalVirtualGroupFamilyId: 0,
             primarySpSignature: "",
             chargedReadQuota: 0,
             extraData: abi.encode(extraData)
@@ -258,6 +261,7 @@ contract BucketHubTest is Test, BucketHub {
             paymentAddress: address(this),
             primarySpAddress: address(this),
             primarySpApprovalExpiredHeight: 0,
+            globalVirtualGroupFamilyId: 0,
             primarySpSignature: "",
             chargedReadQuota: 0,
             extraData: ""


### PR DESCRIPTION
### Description

This pr is to add missing property `globalVirtualGroupFamilyId` to `CreateBucketSynPackage`

### Changes

Notable changes:
* change `primarySpApprovalExpiredHeight` type from `uint256` to `uint64`
* add `globalVirtualGroupFamilyId` to `CreateBucketSynPackage`