### PR TITLE
feat: add PermissionDeployer for PermissionHub upgrades

### DIFF
--- a/contracts/PermissionDeployer.sol
+++ b/contracts/PermissionDeployer.sol
@@ -1,0 +1,111 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+pragma solidity ^0.8.0;
+
+import "@openzeppelin/contracts/proxy/transparent/ProxyAdmin.sol";
+import "@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
+
+import "./Deployer.sol";
+import "./GnfdProxy.sol";
+import "./GnfdProxyAdmin.sol";
+import "./GnfdLightClient.sol";
+import "./CrossChain.sol";
+import "./RelayerHub.sol";
+import "./middle-layer/GovHub.sol";
+import "./middle-layer/TokenHub.sol";
+import "./middle-layer/resource-mirror/BucketHub.sol";
+import "./middle-layer/resource-mirror/ObjectHub.sol";
+import "./middle-layer/resource-mirror/GroupHub.sol";
+import "./middle-layer/resource-mirror/PermissionHub.sol";
+
+contract PermissionDeployer {
+    address public immutable proxyPermissionHub;
+    Deployer public immutable oldDeployer;
+
+    address public implPermissionHub;
+    address public permissionToken;
+    address public addPermissionHub;
+    bytes20 public deployRepoCommitId;
+
+    bool public deployed;
+    address public operator;
+
+    modifier onlyOperator() {
+        require(msg.sender == operator, "only operator");
+        _;
+    }
+
+    constructor(address _oldDeployer, bytes20 _deployRepoCommitId) {
+        operator = msg.sender;
+        oldDeployer = Deployer(_oldDeployer);
+        deployRepoCommitId = _deployRepoCommitId;
+
+        proxyPermissionHub = calcCreateAddress(address(this), uint8(1));
+    }
+
+    function deploy(
+        address _implPermissionHub,
+        address _addPermissionHub,
+        address _permissionToken
+    ) external onlyOperator {
+        require(!deployed, "only not deployed");
+        deployed = true;
+        implPermissionHub = _implPermissionHub;
+        permissionToken = _permissionToken;
+        addPermissionHub = _addPermissionHub;
+
+        address deployedProxyPermissionHub = address(new GnfdProxy(_implPermissionHub, oldDeployer.proxyAdmin(), ""));
+        require(deployedProxyPermissionHub == proxyPermissionHub, "invalid proxyPermissionHub address");
+        PermissionHub(payable(proxyPermissionHub)).initialize(_permissionToken, _addPermissionHub);
+        PermissionHub(payable(proxyPermissionHub)).initializeV2();
+
+        require(
+            PermissionHub(payable(proxyPermissionHub)).additional() == _addPermissionHub,
+            "invalid _addPermissionHub address on proxyPermissionHub"
+        );
+        require(
+            Config(deployedProxyPermissionHub).PROXY_ADMIN() == oldDeployer.proxyAdmin(),
+            "invalid proxyAdmin address on Config"
+        );
+        require(
+            Config(deployedProxyPermissionHub).GOV_HUB() == oldDeployer.proxyGovHub(),
+            "invalid proxyGovHub address on Config"
+        );
+        require(
+            Config(deployedProxyPermissionHub).CROSS_CHAIN() == oldDeployer.proxyCrossChain(),
+            "invalid proxyCrossChain address on Config"
+        );
+        require(
+            Config(deployedProxyPermissionHub).TOKEN_HUB() == oldDeployer.proxyTokenHub(),
+            "invalid proxyTokenHub address on Config"
+        );
+        require(
+            Config(deployedProxyPermissionHub).GOV_HUB() == oldDeployer.proxyGovHub(),
+            "invalid proxyGovHub address on Config"
+        );
+        require(
+            Config(deployedProxyPermissionHub).RELAYER_HUB() == oldDeployer.proxyRelayerHub(),
+            "invalid proxyRelayerHub address on Config"
+        );
+        require(
+            Config(deployedProxyPermissionHub).PERMISSION_HUB() == deployedProxyPermissionHub,
+            "invalid proxyPermissionHub address on Config"
+        );
+        require(
+            Config(_addPermissionHub).PERMISSION_HUB() == deployedProxyPermissionHub,
+            "invalid proxyPermissionHub address on Config"
+        );
+        require(
+            Config(_addPermissionHub).CROSS_CHAIN() == oldDeployer.proxyCrossChain(),
+            "invalid proxyPermissionHub address on Config"
+        );
+    }
+
+    function _isContract(address account) internal view returns (bool) {
+        return account.code.length > 0;
+    }
+
+    function calcCreateAddress(address _deployer, uint8 _nonce) public pure returns (address) {
+        return address(uint160(uint256(keccak256(abi.encodePacked(bytes1(0xd6), bytes1(0x94), _deployer, _nonce)))));
+    }
+}

--- a/scripts/2-verify-scan.ts
+++ b/scripts/2-verify-scan.ts
@@ -87,7 +87,6 @@ const main = async () => {
         await run('verify:verify', { address: implGroupHub });
         await run('verify:verify', { address: implPermissionHub });
         log('proxyAdmin and all impl contract verified');
-
     } catch (e) {
         log('verify error', e);
     }

--- a/scripts/8-deploy-permissionHub.ts
+++ b/scripts/8-deploy-permissionHub.ts
@@ -1,0 +1,108 @@
+import { PermissionDeployer } from '../typechain-types';
+import { setConstantsToConfig, sleep, toHuman } from './helper';
+import fs from 'fs';
+import { execSync } from 'child_process';
+import { waitTx } from '../test/helper';
+const { ethers, run } = require('hardhat');
+const log = console.log;
+
+const main = async () => {
+    const commitId = await getCommitId();
+
+    const { chainId } = await ethers.provider.getNetwork();
+    log('chainId', chainId);
+    const deployFile = `${__dirname}/../deployment/${chainId}-deployment.json`
+    let contracts: any = require(deployFile);
+
+    const [operator] = await ethers.getSigners();
+    const balance = await ethers.provider.getBalance(operator.address);
+    log('operator.address: ', operator.address, toHuman(balance));
+
+    const permissionDeployer = (await deployContract('PermissionDeployer', contracts.Deployer, '0x' + commitId)) as PermissionDeployer;
+    contracts.PermissionDeployer = permissionDeployer.address;
+    contracts.PermissionHub = await permissionDeployer.proxyPermissionHub();
+    await setConstantsToConfig({
+        proxyAdmin: contracts.ProxyAdmin,
+        proxyGovHub: contracts.GovHub,
+        proxyCrossChain: contracts.CrossChain,
+        proxyTokenHub: contracts.TokenHub,
+        proxyLightClient: contracts.LightClient,
+        proxyRelayerHub: contracts.RelayerHub,
+        proxyBucketHub: contracts.BucketHub,
+        proxyObjectHub: contracts.ObjectHub,
+        proxyGroupHub: contracts.GroupHub,
+        proxyPermissionHub: contracts.PermissionHub,
+        emergencyOperator: contracts.EmergencyOperator,
+        emergencyUpgradeOperator: contracts.EmergencyUpgradeOperator,
+    });
+
+    const implPermissionHub = await deployContract('PermissionHub');
+    const addPermissionHub = await deployContract('AdditionalPermissionHub');
+    const permissionToken = await deployContract(
+        'ERC721NonTransferable',
+        'GreenField-PermissionToken',
+        'PERMISSION',
+        'permission',
+        contracts.PermissionHub
+    );
+    log('deploy permission token success', permissionToken.address);
+
+    await waitTx(
+        permissionDeployer.deploy(
+            implPermissionHub.address,
+            addPermissionHub.address,
+            permissionToken.address
+        )
+    );
+    contracts.AdditionalPermissionHub = addPermissionHub.address;
+    contracts.PermissionToken = permissionToken.address;
+
+    try {
+        await run('verify:verify', {
+            address: permissionDeployer.address,
+            constructorArguments: [contracts.Deployer, '0x' + commitId],
+        });
+        await run('verify:verify', { address: implPermissionHub.address });
+        await run('verify:verify', { address: addPermissionHub.address });
+        await run('verify:verify', {
+            address: permissionToken.address,
+            constructorArguments: [
+                'GreenField-Permission',
+                'PERMISSION',
+                'permission',
+                contracts.PermissionHub,
+            ],
+        });
+
+        log('implPermissionHub addPermissionHub permissionToken contract verified');
+    } catch (e) {
+        log('verify error', e);
+    }
+
+    fs.writeFileSync(deployFile, JSON.stringify(contracts, null, 2));
+};
+
+const getCommitId = async (): Promise<string> => {
+    try {
+        const result = execSync('git rev-parse HEAD');
+        log('getCommitId', result.toString().trim());
+        return result.toString().trim();
+    } catch (e) {
+        console.error('getCommitId error', e);
+        return '';
+    }
+};
+
+const deployContract = async (factoryPath: string, ...args: any) => {
+    const factory = await ethers.getContractFactory(factoryPath);
+    const contract = await factory.deploy(...args);
+    await contract.deployTransaction.wait(1);
+    return contract;
+};
+
+main()
+    .then(() => process.exit(0))
+    .catch((error) => {
+        console.error(error);
+        process.exit(1);
+    });


### PR DESCRIPTION
### Description

add PermissionDeployer for PermissionHub upgrades

### Rationale

Considering the particularity of upgradable contracts, compatible upgrade deployer  must be used

### Changes

Notable changes:
* add PermissionDeployer 
* add Permission deploy script
* ...