### PR TITLE
feat: add `GreenfieldExecutor`

### DIFF
--- a/contracts/Config.sol
+++ b/contracts/Config.sol
@@ -12,6 +12,7 @@ abstract contract Config {
     uint8 public constant OBJECT_CHANNEL_ID = 0x05;
     uint8 public constant GROUP_CHANNEL_ID = 0x06;
     uint8 public constant PERMISSION_CHANNEL_ID = 0x07;
+    uint8 public constant GNFD_EXECUTOR_CHANNEL_ID = 0x09;
 
     // contract address
     // will calculate their deployed addresses from deploy script
@@ -27,6 +28,7 @@ abstract contract Config {
     address public constant EMERGENCY_OPERATOR = address(0);
     address public constant EMERGENCY_UPGRADE_OPERATOR = address(0);
     address public constant PERMISSION_HUB = address(0);
+    address public constant GNFD_EXECUTOR = address(0);
 
     // PlaceHolder reserve for future usage
     uint256[50] private configSlots;

--- a/contracts/CrossChain.sol
+++ b/contracts/CrossChain.sol
@@ -175,6 +175,9 @@ contract CrossChain is Config, Initializable, ICrossChain {
         channelHandlerMap[MULTI_MESSAGE_CHANNEL_ID] = MULTI_MESSAGE;
         registeredContractChannelMap[MULTI_MESSAGE][MULTI_MESSAGE_CHANNEL_ID] = true;
 
+        channelHandlerMap[GNFD_EXECUTOR_CHANNEL_ID] = GNFD_EXECUTOR;
+        registeredContractChannelMap[MULTI_MESSAGE][GNFD_EXECUTOR_CHANNEL_ID] = true;
+
         callbackGasPrice = 4 gwei;
         batchSizeForOracle = 50;
 

--- a/contracts/CrossChain.sol
+++ b/contracts/CrossChain.sol
@@ -176,7 +176,7 @@ contract CrossChain is Config, Initializable, ICrossChain {
         registeredContractChannelMap[MULTI_MESSAGE][MULTI_MESSAGE_CHANNEL_ID] = true;
 
         channelHandlerMap[GNFD_EXECUTOR_CHANNEL_ID] = GNFD_EXECUTOR;
-        registeredContractChannelMap[MULTI_MESSAGE][GNFD_EXECUTOR_CHANNEL_ID] = true;
+        registeredContractChannelMap[GNFD_EXECUTOR][GNFD_EXECUTOR_CHANNEL_ID] = true;
 
         callbackGasPrice = 4 gwei;
         batchSizeForOracle = 50;

--- a/contracts/Deployer.sol
+++ b/contracts/Deployer.sol
@@ -16,6 +16,7 @@ import "./middle-layer/resource-mirror/BucketHub.sol";
 import "./middle-layer/resource-mirror/ObjectHub.sol";
 import "./middle-layer/resource-mirror/GroupHub.sol";
 import "./middle-layer/resource-mirror/PermissionHub.sol";
+import "./middle-layer/GreenfieldExecutor.sol";
 
 contract Deployer {
     uint16 public immutable gnfdChainId;
@@ -30,6 +31,7 @@ contract Deployer {
     address public immutable proxyObjectHub;
     address public immutable proxyGroupHub;
     address public immutable proxyPermissionHub;
+    address public immutable proxyGreenfieldExecutor;
 
     bytes public initConsensusStateBytes;
     address public implGovHub;
@@ -41,6 +43,7 @@ contract Deployer {
     address public implObjectHub;
     address public implGroupHub;
     address public implPermissionHub;
+    address public implGreenfieldExecutor;
 
     address public addBucketHub;
     address public addObjectHub;
@@ -85,6 +88,7 @@ contract Deployer {
 
         // @dev
         proxyPermissionHub = calcCreateAddress(address(this), uint8(10));
+        proxyGreenfieldExecutor = calcCreateAddress(address(this), uint8(11));
 
         // 1. proxyAdmin
         address deployedProxyAdmin = address(new GnfdProxyAdmin());
@@ -138,7 +142,11 @@ contract Deployer {
         address deployedProxyPermissionHub = address(new GnfdProxy(implPermissionHub, proxyAdmin, ""));
         require(deployedProxyPermissionHub == proxyPermissionHub, "invalid proxyPermissionHub address");
 
-        // 11. init contracts, set contracts addresses to GovHub
+        // 11. GreenfieldExecutor
+        address deployedProxyGreenfieldExecutor = address(new GnfdProxy(implGreenfieldExecutor, proxyAdmin, ""));
+        require(deployedProxyGreenfieldExecutor == proxyGreenfieldExecutor, "invalid proxyGreenfieldExecutor address");
+
+        // 12. init contracts, set contracts addresses to GovHub
         CrossChain(payable(proxyCrossChain)).initialize(gnfdChainId, enableCrossChainTransfer);
         TokenHub(payable(proxyTokenHub)).initialize();
         GnfdLightClient(payable(proxyLightClient)).initialize(_initConsensusStateBytes);
@@ -152,6 +160,7 @@ contract Deployer {
         GroupHub(payable(proxyGroupHub)).initializeV2();
         PermissionHub(payable(proxyPermissionHub)).initialize(permissionToken, addPermissionHub);
         PermissionHub(payable(proxyPermissionHub)).initializeV2();
+        GreenfieldExecutor(payable(proxyGreenfieldExecutor)).initialize();
 
         require(Config(deployedProxyCrossChain).PROXY_ADMIN() == proxyAdmin, "invalid proxyAdmin address on Config");
         require(Config(deployedProxyCrossChain).GOV_HUB() == proxyGovHub, "invalid proxyGovHub address on Config");
@@ -175,7 +184,7 @@ contract Deployer {
 
     function _init(address[] memory addrs) internal {
         // use address list to avoid stack too deep
-        require(addrs.length == 18, "invalid addrs length");
+        require(addrs.length == 19, "invalid addrs length");
 
         require(_isContract(addrs[0]), "invalid implGovHub");
         require(_isContract(addrs[1]), "invalid implCrossChain");
@@ -196,6 +205,7 @@ contract Deployer {
         require(_isContract(addrs[15]), "invalid implPermissionHub");
         require(_isContract(addrs[16]), "invalid addPermissionHub");
         require(_isContract(addrs[17]), "invalid permissionToken");
+        require(_isContract(addrs[18]), "invalid greenfieldExecutor");
 
         implGovHub = addrs[0];
         implCrossChain = addrs[1];
@@ -216,6 +226,7 @@ contract Deployer {
         implPermissionHub = addrs[15];
         addPermissionHub = addrs[16];
         permissionToken = addrs[17];
+        implGreenfieldExecutor = addrs[18];
     }
 
     function _isContract(address account) internal view returns (bool) {

--- a/contracts/interface/IGreenfieldExecutor.sol
+++ b/contracts/interface/IGreenfieldExecutor.sol
@@ -3,5 +3,5 @@
 pragma solidity ^0.8.0;
 
 interface IGreenfieldExecutor {
-    function execute(bytes[] calldata _data) external payable returns (bool);
+    function execute(uint8[] calldata _msgTypes, bytes[] calldata _msgBytes) external payable returns (bool);
 }

--- a/contracts/interface/IGreenfieldExecutor.sol
+++ b/contracts/interface/IGreenfieldExecutor.sol
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+pragma solidity ^0.8.0;
+
+interface IGreenfieldExecutor {
+    function execute(bytes[] calldata _data) external payable returns (bool);
+}

--- a/contracts/middle-layer/GreenfieldExecutor.sol
+++ b/contracts/middle-layer/GreenfieldExecutor.sol
@@ -12,23 +12,22 @@ contract GreenfieldExecutor is Config, Initializable, IGreenfieldExecutor {
     // 1: CreatePaymentAccount
     // 2: Deposit
     // 3: DisableRefund
-    // 4: UpdateParams
-    // 5: Withdraw
-    // 6: MigrateBucket
-    // 7: CancelMigrateBucket
-    // 8: CompleteMigrateBucket
-    // 9: RejectMigrateBucket
-    // 10: UpdateBucketInfo
-    // 11: ToggleSPAsDelegatedAgent
-    // 12: DiscontinueBucket
-    // 13: SetBucketFlowRateLimit
-    // 14: CopyObject
-    // 15: DiscontinueObject
-    // 16: UpdateObjectInfo
-    // 17: LeaveGroup
-    // 18: UpdateGroupExtra
-    // 19: SetTag
-    // 20: CancelUpdateObjectContent
+    // 4: Withdraw
+    // 5: MigrateBucket
+    // 6: CancelMigrateBucket
+    // 7: CompleteMigrateBucket
+    // 8: RejectMigrateBucket
+    // 9: UpdateBucketInfo
+    // 10: ToggleSPAsDelegatedAgent
+    // 11: DiscontinueBucket
+    // 12: SetBucketFlowRateLimit
+    // 13: CopyObject
+    // 14: DiscontinueObject
+    // 15: UpdateObjectInfo
+    // 16: LeaveGroup
+    // 17: UpdateGroupExtra
+    // 18: SetTag
+    // 19: CancelUpdateObjectContent
 
     constructor() {
         _disableInitializers();

--- a/contracts/middle-layer/GreenfieldExecutor.sol
+++ b/contracts/middle-layer/GreenfieldExecutor.sol
@@ -46,7 +46,7 @@ contract GreenfieldExecutor is Config, Initializable, IGreenfieldExecutor {
         // generate packages
         bytes[] memory messages = new bytes[](_msgBytes.length);
         for (uint256 i = 0; i < _length; ++i) {
-            require(_msgTypes[i] != MsgType.Unspecified, "invalid message type");
+            require(_msgTypes[i] != 0, "invalid message type");
             messages[i] = abi.encode(msg.sender, _msgTypes[i], _msgBytes[i]);
         }
 

--- a/contracts/middle-layer/GreenfieldExecutor.sol
+++ b/contracts/middle-layer/GreenfieldExecutor.sol
@@ -6,8 +6,9 @@ import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 import "../Config.sol";
 import "../interface/ICrossChain.sol";
 import "../interface/IGreenfieldExecutor.sol";
+import "../interface/IMiddleLayer.sol";
 
-contract GreenfieldExecutor is Config, Initializable, IGreenfieldExecutor {
+contract GreenfieldExecutor is Config, Initializable, IMiddleLayer, IGreenfieldExecutor {
     // Supported message types and its corresponding number
     // 1: CreatePaymentAccount
     // 2: Deposit
@@ -15,19 +16,13 @@ contract GreenfieldExecutor is Config, Initializable, IGreenfieldExecutor {
     // 4: Withdraw
     // 5: MigrateBucket
     // 6: CancelMigrateBucket
-    // 7: CompleteMigrateBucket
-    // 8: RejectMigrateBucket
-    // 9: UpdateBucketInfo
-    // 10: ToggleSPAsDelegatedAgent
-    // 11: DiscontinueBucket
-    // 12: SetBucketFlowRateLimit
-    // 13: CopyObject
-    // 14: DiscontinueObject
-    // 15: UpdateObjectInfo
-    // 16: LeaveGroup
-    // 17: UpdateGroupExtra
-    // 18: SetTag
-    // 19: CancelUpdateObjectContent
+    // 7: UpdateBucketInfo
+    // 8: ToggleSPAsDelegatedAgent
+    // 9: SetBucketFlowRateLimit
+    // 10: CopyObject
+    // 11: UpdateObjectInfo
+    // 12: UpdateGroupExtra
+    // 13: SetTag
 
     constructor() {
         _disableInitializers();
@@ -63,5 +58,27 @@ contract GreenfieldExecutor is Config, Initializable, IGreenfieldExecutor {
         returns (uint256 version, string memory name, string memory description)
     {
         return (1_000_001, "GreenfieldExecutor", "init");
+    }
+
+    function handleSynPackage(uint8, bytes calldata) external returns (bytes memory responsePayload) {
+        revert("receive unexpected syn package");
+    }
+
+    function handleAckPackage(
+        uint8,
+        uint64,
+        bytes calldata,
+        uint256
+    ) external returns (uint256 remainingGas, address refundAddress) {
+        revert("receive unexpected ack package");
+    }
+
+    function handleFailAckPackage(
+        uint8,
+        uint64,
+        bytes calldata,
+        uint256
+    ) external returns (uint256 remainingGas, address refundAddress) {
+        revert("receive unexpected fail ack package");
     }
 }

--- a/contracts/middle-layer/GreenfieldExecutor.sol
+++ b/contracts/middle-layer/GreenfieldExecutor.sol
@@ -9,27 +9,33 @@ import "../interface/IGreenfieldExecutor.sol";
 import "../interface/IMiddleLayer.sol";
 
 contract GreenfieldExecutor is Config, Initializable, IMiddleLayer, IGreenfieldExecutor {
-    // Supported message types and its corresponding number
-    // 1: CreatePaymentAccount
-    // 2: Deposit
-    // 3: DisableRefund
-    // 4: Withdraw
-    // 5: MigrateBucket
-    // 6: CancelMigrateBucket
-    // 7: UpdateBucketInfo
-    // 8: ToggleSPAsDelegatedAgent
-    // 9: SetBucketFlowRateLimit
-    // 10: CopyObject
-    // 11: UpdateObjectInfo
-    // 12: UpdateGroupExtra
-    // 13: SetTag
-
     constructor() {
         _disableInitializers();
     }
 
     function initialize() public initializer {}
 
+    /**
+     * @notice Send messages to GNFD
+     *
+     * @param _msgTypes The greenfield message types.
+     * Supported message types and its corresponding number
+     * 1: CreatePaymentAccount
+     * 2: Deposit
+     * 3: DisableRefund
+     * 4: Withdraw
+     * 5: MigrateBucket
+     * 6: CancelMigrateBucket
+     * 7: UpdateBucketInfo
+     * 8: ToggleSPAsDelegatedAgent
+     * 9: SetBucketFlowRateLimit
+     * 10: CopyObject
+     * 11: UpdateObjectInfo
+     * 12: UpdateGroupExtra
+     * 13: SetTag
+     * @param _msgBytes The greenfield message bytes encoded by protobuf.
+     * Please refer to https://docs.bnbchain.org/greenfield-docs/docs/guide/core-concept/cross-chain/executor/ for more details.
+     */
     function execute(uint8[] calldata _msgTypes, bytes[] calldata _msgBytes) external payable override returns (bool) {
         uint256 _length = _msgTypes.length;
         require(_length > 0, "empty data");

--- a/contracts/middle-layer/GreenfieldExecutor.sol
+++ b/contracts/middle-layer/GreenfieldExecutor.sol
@@ -60,7 +60,7 @@ contract GreenfieldExecutor is Config, Initializable, IMiddleLayer, IGreenfieldE
         return (1_000_001, "GreenfieldExecutor", "init");
     }
 
-    function handleSynPackage(uint8, bytes calldata) external returns (bytes memory responsePayload) {
+    function handleSynPackage(uint8, bytes calldata) external pure returns (bytes memory responsePayload) {
         revert("receive unexpected syn package");
     }
 
@@ -69,7 +69,7 @@ contract GreenfieldExecutor is Config, Initializable, IMiddleLayer, IGreenfieldE
         uint64,
         bytes calldata,
         uint256
-    ) external returns (uint256 remainingGas, address refundAddress) {
+    ) external pure returns (uint256 remainingGas, address refundAddress) {
         revert("receive unexpected ack package");
     }
 
@@ -78,7 +78,7 @@ contract GreenfieldExecutor is Config, Initializable, IMiddleLayer, IGreenfieldE
         uint64,
         bytes calldata,
         uint256
-    ) external returns (uint256 remainingGas, address refundAddress) {
+    ) external pure returns (uint256 remainingGas, address refundAddress) {
         revert("receive unexpected fail ack package");
     }
 }

--- a/contracts/middle-layer/GreenfieldExecutor.sol
+++ b/contracts/middle-layer/GreenfieldExecutor.sol
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+pragma solidity ^0.8.0;
+
+import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
+import "../Config.sol";
+import "../interface/ICrossChain.sol";
+import "../interface/IGreenfieldExecutor.sol";
+
+contract GreenfieldExecutor is Config, Initializable, IGreenfieldExecutor {
+    constructor() {
+        _disableInitializers();
+    }
+    function initialize() public initializer {}
+
+    function execute(bytes[] calldata _data) external payable override returns (bool) {
+        uint256 _length = _data.length;
+        require(_length > 0, "empty data");
+
+        (uint256 relayFee, ) = ICrossChain(CROSS_CHAIN).getRelayFees();
+        require(msg.value == (relayFee * _length), "not enough value");
+
+        // generate packages
+        bytes[] memory messages = new bytes[](_data.length);
+        for (uint256 i = 0; i < _length; ++i) {
+            messages[i] = abi.encode(_data[i], msg.sender);
+        }
+
+        // send sync package
+        ICrossChain(CROSS_CHAIN).sendSynPackage(GNFD_EXECUTOR_CHANNEL_ID, abi.encode(messages), msg.value, 0);
+
+        return true;
+    }
+
+    function versionInfo()
+        external
+        pure
+        override
+        returns (uint256 version, string memory name, string memory description)
+    {
+        return (1_000_001, "GreenfieldExecutor", "init");
+    }
+}

--- a/contracts/middle-layer/GreenfieldExecutor.sol
+++ b/contracts/middle-layer/GreenfieldExecutor.sol
@@ -8,42 +8,41 @@ import "../interface/ICrossChain.sol";
 import "../interface/IGreenfieldExecutor.sol";
 
 contract GreenfieldExecutor is Config, Initializable, IGreenfieldExecutor {
-    enum MsgType {
-        Unspecified,
-        CreatePaymentAccount,
-        Deposit,
-        DisableRefund,
-        UpdateParams,
-        Withdraw,
-        MigrateBucket,
-        CancelMigrateBucket,
-        CompleteMigrateBucket,
-        RejectMigrateBucket,
-        UpdateBucketInfo,
-        ToggleSPAsDelegatedAgent,
-        DiscontinueBucket,
-        SetBucketFlowRateLimit,
-        CopyObject,
-        DiscontinueObject,
-        UpdateObjectInfo,
-        LeaveGroup,
-        UpdateGroupExtra,
-        SetTag,
-        CancelUpdateObjectContent
-    }
+    // Supported message types and its corresponding number
+    // 1: CreatePaymentAccount
+    // 2: Deposit
+    // 3: DisableRefund
+    // 4: UpdateParams
+    // 5: Withdraw
+    // 6: MigrateBucket
+    // 7: CancelMigrateBucket
+    // 8: CompleteMigrateBucket
+    // 9: RejectMigrateBucket
+    // 10: UpdateBucketInfo
+    // 11: ToggleSPAsDelegatedAgent
+    // 12: DiscontinueBucket
+    // 13: SetBucketFlowRateLimit
+    // 14: CopyObject
+    // 15: DiscontinueObject
+    // 16: UpdateObjectInfo
+    // 17: LeaveGroup
+    // 18: UpdateGroupExtra
+    // 19: SetTag
+    // 20: CancelUpdateObjectContent
 
     constructor() {
         _disableInitializers();
     }
+
     function initialize() public initializer {}
 
-    function execute(MsgType[] calldata _msgTypes, bytes[] calldata _msgBytes) external payable override returns (bool) {
+    function execute(uint8[] calldata _msgTypes, bytes[] calldata _msgBytes) external payable override returns (bool) {
         uint256 _length = _msgTypes.length;
         require(_length > 0, "empty data");
         require(_length == _msgBytes.length, "length not match");
 
         (uint256 relayFee, ) = ICrossChain(CROSS_CHAIN).getRelayFees();
-        require(msg.value == (relayFee * _length), "not enough value");
+        require(msg.value == relayFee, "invalid value for relay fee");
 
         // generate packages
         bytes[] memory messages = new bytes[](_msgBytes.length);

--- a/foundry-tests/GnfdExecutor.t.sol
+++ b/foundry-tests/GnfdExecutor.t.sol
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+pragma solidity ^0.8.0;
+
+import "forge-std/Test.sol";
+
+import "contracts/CrossChain.sol";
+import "../contracts/middle-layer/GreenfieldExecutor.sol";
+
+contract GnfdExecutorTest is Test, GreenfieldExecutor {
+    event CrossChainPackage(
+        uint32 srcChainId,
+        uint32 dstChainId,
+        uint64 indexed oracleSequence,
+        uint64 indexed packageSequence,
+        uint8 indexed channelId,
+        bytes payload
+    );
+
+    GreenfieldExecutor public gnfdExecutor;
+    CrossChain public crossChain;
+
+    function setUp() public {
+        vm.createSelectFork("local");
+
+        crossChain = CrossChain(CROSS_CHAIN);
+        gnfdExecutor = GreenfieldExecutor(GNFD_EXECUTOR);
+
+        vm.label(CROSS_CHAIN, "crossChain");
+        vm.label(GNFD_EXECUTOR, "gnfdExecutor");
+    }
+
+    function testExecute() public {
+        uint8[] memory msgTypes = new uint8[](1);
+        bytes[] memory msgBytes = new bytes[](1);
+        msgTypes[0] = 1;
+        msgBytes[0] = hex"0a2a307866333946643665353161616438384636463463653661423838323732373963666646623932323636";
+
+        vm.expectEmit(false, false, true, false, address(crossChain));
+        emit CrossChainPackage(0, 0, 0, 0, GNFD_EXECUTOR_CHANNEL_ID, hex"");
+        gnfdExecutor.execute(msgTypes, msgBytes);
+    }
+}

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -40,7 +40,8 @@ const config: HardhatUserConfig = {
                 '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80',  // developer
                 '0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d',  // relayer
                 '0x23400f0b4857a2228218fa74fbcac1f2285c03e60d590afe8fa3dc93692aa7be', // faucet
-            ]
+            ],
+            gasPrice: 10 * 1e9
         },
         'bsc-testnet': {
             url: process.env.BSC_TESTNET_RPC || 'https://data-seed-prebsc-1-s1.binance.org:8545/',

--- a/scripts/1-deploy.ts
+++ b/scripts/1-deploy.ts
@@ -119,6 +119,7 @@ const main = async () => {
     const proxyObjectHub = await deployer.proxyObjectHub();
     const proxyGroupHub = await deployer.proxyGroupHub();
     const proxyPermissionHub = await deployer.proxyPermissionHub();
+    const proxyGreenfieldExecutor = await deployer.proxyGreenfieldExecutor();
 
     // Set all generated contracts to Config contracts
     await setConstantsToConfig({
@@ -132,6 +133,7 @@ const main = async () => {
         proxyObjectHub,
         proxyGroupHub,
         proxyPermissionHub,
+        proxyGreenfieldExecutor,
         emergencyOperator,
         emergencyUpgradeOperator,
     });
@@ -162,6 +164,9 @@ const main = async () => {
 
     const implPermissionHub = await deployContract('PermissionHub');
     log('deploy implPermissionHub success', implPermissionHub.address);
+
+    const implGreenfieldExecutor = await deployContract('GreenfieldExecutor');
+    log('deploy implGreenfieldExecutor success', implGreenfieldExecutor.address);
 
     const addBucketHub = await deployContract('AdditionalBucketHub');
     log('deploy addBucketHub success', addBucketHub.address);
@@ -234,6 +239,7 @@ const main = async () => {
         implPermissionHub.address,
         addPermissionHub.address,
         permissionToken.address,
+        implGreenfieldExecutor.address,
     ];
 
     let tx = await deployer.deploy(initAddrs, initConsensusStateBytes);
@@ -260,6 +266,7 @@ const main = async () => {
         ObjectHub: proxyObjectHub,
         GroupHub: proxyGroupHub,
         PermissionHub: proxyPermissionHub,
+        GreenfieldExecutor: proxyGreenfieldExecutor,
 
         AdditionalBucketHub: addBucketHub.address,
         AdditionalObjectHub: addObjectHub.address,

--- a/scripts/helper.ts
+++ b/scripts/helper.ts
@@ -29,6 +29,7 @@ export async function setConstantsToConfig(contracts: any) {
     const proxyGroupHub = contracts.proxyGroupHub;
 
     const proxyPermissionHub = contracts.proxyPermissionHub;
+    const proxyGreenfieldExecutor = contracts.proxyGreenfieldExecutor;
     const emergencyOperator = contracts.emergencyOperator;
     const emergencyUpgradeOperator = contracts.emergencyUpgradeOperator;
 
@@ -47,6 +48,7 @@ export async function setConstantsToConfig(contracts: any) {
         .replace(/OBJECT_HUB = .*/g, `OBJECT_HUB = ${proxyObjectHub};`)
         .replace(/GROUP_HUB = .*/g, `GROUP_HUB = ${proxyGroupHub};`)
         .replace(/PERMISSION_HUB = .*/g, `PERMISSION_HUB = ${proxyPermissionHub};`)
+        .replace(/GNFD_EXECUTOR = .*/g, `GNFD_EXECUTOR = ${proxyGreenfieldExecutor};`)
         .replace(/EMERGENCY_OPERATOR = .*/g, `EMERGENCY_OPERATOR = ${emergencyOperator};`)
         .replace(
             /EMERGENCY_UPGRADE_OPERATOR = .*/g,


### PR DESCRIPTION
### Description

This pr is to add a new system contract `GreenfieldExecutor` which is used to send greenfield msgs from BSC to greenfield.

For more information, please refer to [BEP363](https://github.com/bnb-chain/BEPs/pull/363).

### Rationale

tell us why we need these changes...

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add new cross chain channel `GNFD_EXECUTOR_CHANNEL` and corresponding contract `GreenfieldExecutor`
