### PR TITLE
feat: update channel remove stale

### DIFF
--- a/contracts/CrossChain.sol
+++ b/contracts/CrossChain.sol
@@ -447,6 +447,12 @@ contract CrossChain is Config, Initializable, ICrossChain {
             }
 
             require(_isContract(handlerContract), "address is not a contract");
+
+            address oldHandler = channelHandlerMap[channelId];
+            if (oldHandler != address(0)) {
+                registeredContractChannelMap[oldHandler][channelId] = false;
+            }
+
             channelHandlerMap[channelId] = handlerContract;
             registeredContractChannelMap[handlerContract][channelId] = true;
             emit AddChannel(channelId, handlerContract);


### PR DESCRIPTION
### Description
 This PR prevents new stale authorization from future handler rotations.
It does not automatically clean up already-existing historical stale entries created before this patch.
Historical cleanup (if needed) should be handled by governance operations / follow-up migration.

### Rationale

currently new authorization will be added while old ones are not removed, although it does not have a security concern now, we better clean them for code cosistency.

### Example
N/A

### Changes

Notable changes:
* crosschain handler